### PR TITLE
Change message to an ephemeral message, so only the current user sees…

### DIFF
--- a/slack/controllers/displayTeam.js
+++ b/slack/controllers/displayTeam.js
@@ -26,7 +26,7 @@ const displayTeam = async (web, db) => {
     blocks: Team(teams)
   }
 
-  return web.chat.postMessage(message)
+  return web.chat.postEphemeral(message);
 }
 
 module.exports = displayTeam;

--- a/slack/listeners/events.js
+++ b/slack/listeners/events.js
@@ -6,7 +6,7 @@ module.exports = (slackEvents, web) => {
   // Listens for incoming "app mentions"
   slackEvents.on('app_mention', (event) => {
 
-    if(event.text.includes("team")) return displayTeam(web, Team);
+    if(event.text.includes("team")) return displayTeam(web, Team, event);
 
   });
 

--- a/slack/listeners/interactions.js
+++ b/slack/listeners/interactions.js
@@ -13,21 +13,21 @@ module.exports = (slackInteractions, web) => {
   });
 
   // Handles the user's submission of the "team create" modal
-  // slackInteractions.action({ view: { callbackId: 'submit_team'} }, (payload, response) => createTeam(payload, Team));
-  slackInteractions.action({ view: { callbackId: 'submit_team'} }, (payload, response) => {
-    // console.log('response', response);
-    const message = {
-      channel: 'iesd-bot',
-      text: 'Hello world',
-      // blocks: Team(teams)
-    }
-    try{
-      displayTeam(web, Team);
-    }
-    catch(err) {
-      console.log('No work', err);
-    }
-  });
+  slackInteractions.action({ view: { callbackId: 'submit_team'} }, (payload, response) => createTeam(payload, Team));
+  // slackInteractions.action({ view: { callbackId: 'submit_team'} }, (payload, response) => {
+  //   // console.log('response', response);
+  //   const message = {
+  //     channel: 'iesd-bot',
+  //     text: 'Hello world',
+  //     // blocks: Team(teams)
+  //   }
+  //   try{
+  //     displayTeam(web, Team);
+  //   }
+  //   catch(err) {
+  //     console.log('No work', err);
+  //   }
+  // });
 
   // Handles adding the current user when they click "choose" to the team
   slackInteractions.action({ actionId: 'team_select' }, (payload, response) => addUserToTeam(payload, Team));


### PR DESCRIPTION
IESD bot now sends chat message as an ephemeral message. This means only the requesting user will see the message from the bot.