### PR TITLE
Create handleCreateTeam.js 

### DIFF
--- a/slack/controllers/createTeam.js
+++ b/slack/controllers/createTeam.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 
-const createTeam = (payload, db) => {
+const createTeam = async (payload, db) => {
   const values = payload.view.state.values;
 
   let teamName;
@@ -20,7 +20,7 @@ const createTeam = (payload, db) => {
     }
   }
 
-  axios.get('https://api.meetup.com/iesd-meetup/events?&sign=true&photo-host=public')
+  await axios.get('https://api.meetup.com/iesd-meetup/events?&sign=true&photo-host=public')
   .then(response => {
     const events = response.data;
     

--- a/slack/controllers/handleCreateTeam.js
+++ b/slack/controllers/handleCreateTeam.js
@@ -1,0 +1,11 @@
+// controllers
+const refreshTeamMessage = require('./refreshTeamMessage');
+const createTeam = require('./createTeam');
+
+const handleCreateTeam = async (payload, db) => {
+  await createTeam(payload, db);
+
+  refreshTeamMessage(db, payload);
+}
+
+module.exports = handleCreateTeam;

--- a/slack/listeners/interactions.js
+++ b/slack/listeners/interactions.js
@@ -1,5 +1,6 @@
 const displayTeamCreate = require('../controllers/displayTeamCreate');
 const createTeam = require('../controllers/createTeam');
+const handleCreateTeam = require('../controllers/handleCreateTeam');
 const handleSelectTeam = require('../controllers/handleSelectTeam');
 const handleLeaveTeam = require('../controllers/handleLeaveTeam');
 const displayTeamManager = require('../controllers/displayTeamManager');
@@ -25,7 +26,7 @@ module.exports = (slackInteractions, web) => {
   slackInteractions.action({ actionId: 'create_team' }, (payload) => displayTeamCreate(web, payload.trigger_id));
 
   // Handles the user's submission of the "team create" modal
-  slackInteractions.viewSubmission({ callbackId: 'submit_team' }, (payload) => createTeam(payload, Team));
+  slackInteractions.viewSubmission({ callbackId: 'submit_team' }, (payload) => handleCreateTeam(payload, Team));
 
   // Handles the user's submission of the "edit team info" modal
   slackInteractions.viewSubmission({ callbackId: 'edit_team_info' }, (payload) => handleEditTeamInfo(payload, Team));


### PR DESCRIPTION
The handleCreateTeam handler function uses both refreshTeamMessage.js and createTeam.js to reload the original message after the user creates a new team.