### PR TITLE
Limit number of team members to 5

### DIFF
--- a/models/Team.js
+++ b/models/Team.js
@@ -16,12 +16,13 @@ const teamSchema = new Schema({
   //   unique: true
   // },
   // Store team member's Slack ID
-  teamMembers: [
-    {
-      type: 'String',
-      unique: true
-    }
-  ],
+  teamMembers: {
+    type:[{
+        type: 'String',
+        unique: true
+    }],
+    validate: [arrayLimit, '{PATH} exceeds the limit of 5']
+  },
   // Whether the team is open, closed or invite-only
   teamSetting: {
     type: 'String'
@@ -31,5 +32,9 @@ const teamSchema = new Schema({
     type: Date,
   }
 });
+
+function arrayLimit(val) {
+  return val.length <= 5;
+}
 
 module.exports = mongoose.model('Team', teamSchema);

--- a/slack/views/ModalMultiUsersSelect.js
+++ b/slack/views/ModalMultiUsersSelect.js
@@ -9,6 +9,7 @@ const ModalMultiUsersSelect = (actionId, initialUsers, placeHolderText, labelTex
         type: "plain_text",
         text: placeHolderText
       },
+      max_selected_items: 5
     },
     label: {
       type: "plain_text",


### PR DESCRIPTION
Changes in this PR:

- Update team model to validate that there is only 5 team members, else it will not change.
- Add max_selected_items field to the view ModalMultiUserSelect.js. This adds a form of feedback on the slack modal when a user attempts to add more than 5 users.