### PR TITLE
Add character limit for team name

### DIFF
--- a/slack/listeners/interactions.js
+++ b/slack/listeners/interactions.js
@@ -41,6 +41,7 @@ module.exports = (slackInteractions, web) => {
   // Handles displaying the "team create" modal
   slackInteractions.action({ actionId: 'create_team' }, (payload) => displayTeamCreate(web, payload.trigger_id));
 
+  // Handle declining request to join team
   slackInteractions.action({ actionId: 'decline_request_to_join' }, (payload) => handleDeclineRequestToJoin(web, payload));
 
   // Handles the user's submission of the "team create" modal

--- a/slack/views/ModalPlainTextInput.js
+++ b/slack/views/ModalPlainTextInput.js
@@ -1,4 +1,24 @@
-const ModalPlainTextInput = (actionId, initialValue, placeHolderText, labelText) => {
+const ModalPlainTextInput = (actionId, initialValue, placeHolderText, labelText, charLimit) => {
+  if(charLimit){
+    return {
+      type: "input",
+      element: {
+        type: "plain_text_input",
+        action_id: actionId,
+        initial_value: initialValue,
+        placeholder: {
+          type: "plain_text",
+          text: placeHolderText
+        },
+        max_length: charLimit
+      },
+      label: {
+        type: "plain_text",
+        text: labelText
+      }
+    }
+  }
+  
   return {
     type: "input",
     element: {

--- a/slack/views/TeamCreateModal.js
+++ b/slack/views/TeamCreateModal.js
@@ -26,7 +26,8 @@ const TeamCreateModal = () => {
         "team_name", // Action ID
         "", // Initial value
         "What would you like to name your team?", // Placeholder Text
-        "Team Name" // Label Text
+        "Team Name", // Label Text
+        54 // Character limit for team name
       ),
       ModalMultiUsersSelect(
         "members", // Action ID

--- a/slack/views/TeamManagerModal.js
+++ b/slack/views/TeamManagerModal.js
@@ -27,7 +27,8 @@ const TeamManagerModal = (teamName, initialUsers, groupSetting) => {
         "team_name", // Action ID
         teamName, // Initial value
         "What would you like to name your team?", // Placeholder Text
-        "Team Name" // Label Text
+        "Team Name", // Label Text
+        54 // Character limit for team name
       ),
       ModalMultiUsersSelect(
         "members", // Action ID


### PR DESCRIPTION
Make character limit for team name by adding a limit to input in ModalPlainTextInput. Character limit is set to a maximum of 54 characters.