### PR TITLE
bug fix for opening manager modal when team setting is invite only

### DIFF
--- a/slack/views/TeamModalSettingSelect.js
+++ b/slack/views/TeamModalSettingSelect.js
@@ -17,9 +17,11 @@ const TeamModalSettingSelect = (initialOptionValue) => {
     case "Invite":
       initialOption.text.text = "Invite Only",
       initialOption.value = "Invite"
+      break;
     case "Closed":
       initialOption.text.text = "Closed",
       initialOption.value = "Closed"
+      break;
   }
 
   return {


### PR DESCRIPTION
When team setting is set to invite only, and the user would open up the team manager modal it would display the default setting as Closed. 